### PR TITLE
fix: don't assume the member will always be included on MESSAGE_CREAT…

### DIFF
--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1158,7 +1158,11 @@ namespace Discord.WebSocket
                                         if (author == null)
                                         {
                                             if (guild != null)
-                                                author = guild.AddOrUpdateUser(data.Member.Value); //per g250k, we can create an entire member now
+                                            {
+                                                author = data.Member.IsSpecified // member isn't always included, but use it when we can
+                                                    ? guild.AddOrUpdateUser(data.Member.Value)
+                                                    : guild.AddOrUpdateUser(data.Author.Value); // user has no guild-specific data
+                                            }
                                             else if (channel is SocketGroupChannel)
                                                 author = (channel as SocketGroupChannel).GetOrAddUser(data.Author.Value);
                                             else


### PR DESCRIPTION
…E (#1167)

* fix: don't assume the member will always be included on MESSAGE_CREATE

This resolves #1153.

Member objects are only included on a message when the user has
transitioned from an offline state to an online state (i think?), so
this change will fall back to the prior behavior, where we just create
an incomplete member object for these states.

* lint: use a ternary in place of an if/else block